### PR TITLE
update de-follow btn selector Fix: fdfmode_classic #42

### DIFF
--- a/modules/mode/fdfmode_classic.js
+++ b/modules/mode/fdfmode_classic.js
@@ -305,9 +305,9 @@ class Fdfmode_classic extends Manager_state {
         } while (retry == 1);
 
         try {
-            await this.bot.waitForSelector("header section > div:nth-child(2) button");
-            let button = await this.bot.$("header section > div:nth-child(2) button");
-            let button_before_click = await this.bot.evaluate(el => el.innerHTML, await this.bot.$("header section > div:nth-child(2) button"));
+            await this.bot.waitForSelector("header section div:nth-child(1) button");
+            let button = await this.bot.$("header section div:nth-child(1) button");
+            let button_before_click = await this.bot.evaluate(el => el.innerHTML, await this.bot.$("header section div:nth-child(1) button"));
             this.log.info("button text before click: " + button_before_click);
 
             if (this.photo_liked[this.photo_current] > 1) {
@@ -325,8 +325,8 @@ class Fdfmode_classic extends Manager_state {
 
                 await this.utils.sleep(this.utils.random_interval(1, 2));
 
-                await this.bot.waitForSelector("header section > div:nth-child(2) button");
-                let button_after_click = await this.bot.evaluate(el => el.innerHTML, await this.bot.$("header section > div:nth-child(2) button"));
+                await this.bot.waitForSelector("header section div:nth-child(1) button");
+                let button_after_click = await this.bot.evaluate(el => el.innerHTML, await this.bot.$("header section div:nth-child(1) button"));
                 this.log.info("button text after click: " + button_after_click);
 
                 if (button_after_click != button_before_click) {


### PR DESCRIPTION
The de follow button selector was still throwing an error even after updating to v0.9.7 so updated the selector to fix it and it seems to be working now. Here's a PR if you want to merge.